### PR TITLE
Add support for default numeric values

### DIFF
--- a/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
@@ -134,7 +134,7 @@ class FieldGenerator {
 			}
 
 			if ($nullable) $decorators[] = 'nullable';
-			if ($default) $decorators[] = $this->getDefault($default, $type);
+			if ($default !== null) $decorators[] = $this->getDefault($default, $type);
 			if ($index) $decorators[] = $this->decorate($index->type, $index->name, true);
 
 			$field = ['field' => $name, 'type' => $type];


### PR DESCRIPTION
Hello,

It would be nice if the generator could extract and set defaults for 0/empty string values. For instance, I have many tinyint values with a default value of 0, which ends up without the ->default() decorator.

Running the migrations under SQLite, the default is set to NULL with a NOT NULL constraint, while it should have had a default of 0.
