### PR TITLE
added support for named foreign keys

### DIFF
--- a/src/Xethron/MigrationsGenerator/Generators/ForeignKeyGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/ForeignKeyGenerator.php
@@ -18,6 +18,7 @@ class ForeignKeyGenerator {
 
 		foreach ( $foreignKeys as $foreignKey ) {
 			$fields[] = [
+				'name' => $foreignKey->getName(),
 				'field' => $foreignKey->getLocalColumns()[0],
 				'references' => $foreignKey->getForeignColumns()[0],
 				'on' => $foreignKey->getForeignTableName(),

--- a/src/Xethron/MigrationsGenerator/Syntax/AddForeignKeysToTable.php
+++ b/src/Xethron/MigrationsGenerator/Syntax/AddForeignKeysToTable.php
@@ -15,8 +15,9 @@ class AddForeignKeysToTable extends Table {
 	protected function getItem(array $foreignKey)
 	{
 		$output = sprintf(
-			"\$table->foreign('%s')->references('%s')->on('%s')",
+			"\$table->foreign('%s', '%s')->references('%s')->on('%s')",
 			$foreignKey['field'],
+			$foreignKey['name'],
 			$foreignKey['references'],
 			$foreignKey['on']
 		);

--- a/src/Xethron/MigrationsGenerator/Syntax/RemoveForeignKeysFromTable.php
+++ b/src/Xethron/MigrationsGenerator/Syntax/RemoveForeignKeysFromTable.php
@@ -14,6 +14,6 @@ class RemoveForeignKeysFromTable extends Table {
 	 */
 	protected function getItem(array $foreignKey)
 	{
-		return sprintf( "\$table->dropForeign('%s');", strtolower( $this->table .'_'. $foreignKey['field'] .'_foreign' ) );
+		return sprintf( "\$table->dropForeign('%s');", $foreignKey['name'] );
 	}
 }


### PR DESCRIPTION
Thanks for your reverse migration generator, it works pretty well.

When foreign key naming in the existing database differs from the common laravel syntax, the dropForeign() statements are wrong. I've fixed this so that the name of a foreign key is taken from the existing database.

Unfortunately, on MySQL, one still needs to add `$table->engine ='InnoDB';` manually to the migrations create statements. I did not found a way the get the storage engine (in case of MySQL) from the existing table via doctrine/dbal.
