### PR TITLE
Support no interaction mode

### DIFF
--- a/src/Xethron/MigrationsGenerator/MigrateGenerateCommand.php
+++ b/src/Xethron/MigrationsGenerator/MigrateGenerateCommand.php
@@ -149,9 +149,9 @@ class MigrateGenerateCommand extends GeneratorCommand {
 		$tables = $this->removeExcludedTables($tables);
 		$this->info( 'Generating migrations for: '. implode( ', ', $tables ) );
 
-        if (!$this->option( 'no-interaction' )) {
-            $this->log = $this->askYn('Do you want to log these migrations in the migrations table?');
-        }
+		if (!$this->option( 'no-interaction' )) {
+			$this->log = $this->askYn('Do you want to log these migrations in the migrations table?');
+		}
 
 		if ( $this->log ) {
 			$this->repository->setSource( $this->option( 'connection' ) );


### PR DESCRIPTION
This removes the need for interaction and automatically generates the migrations.

This allows us to run the command from within the app as such:

`Artisan::call('migrate:generate', ['--no-interaction' => true, '--tables' => 'categories', '--connection' => 'mysql']);`
