### PR TITLE
Feature/laravel five

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,17 +10,23 @@
 		}
 	],
 	"require": {
-		"php": ">=5.3.0",
+		"php": ">=5.4.0",
 		"illuminate/support": ">=4.1",
-		"way/generators": ">=2.0",
+		"way/generators": "dev-feature/laravel-five-stable",
 		"doctrine/dbal": "~2.4"
 	},
+	"repositories": [
+		{
+			"type": "git",
+			"url": "git@github.com:jamisonvalenta/Laravel-4-Generators.git"
+		}
+	],
 	"autoload": {
 		"psr-0": {
 			"Xethron\\MigrationsGenerator": "src/"
 		}
 	},
-	"minimum-stability": "stable",
+	"minimum-stability": "dev",
 	"require-dev": {
 		"phpunit/phpunit": ">=4.0.0",
 		"mockery/mockery": ">=0.9.0",

--- a/src/Xethron/MigrationsGenerator/Generators/IndexGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/IndexGenerator.php
@@ -60,7 +60,8 @@ class IndexGenerator {
 		$array = ['type' => $type, 'name' => null, 'columns' => $index->getColumns()];
 
 		if ( ! $this->ignoreIndexNames and ! $this->isDefaultIndexName($table, $index->getName(), $type, $index->getColumns())) {
-			$array['name'] = $index->getName();
+			// Sent Index name to exclude spaces
+			$array['name'] = str_replace(' ', '', $index->getName());
 		}
 		return $array;
 	}

--- a/src/Xethron/MigrationsGenerator/MigrationsGeneratorServiceProvider.php
+++ b/src/Xethron/MigrationsGenerator/MigrationsGeneratorServiceProvider.php
@@ -32,6 +32,11 @@ class MigrationsGeneratorServiceProvider extends ServiceProvider {
 		);
 
 		$this->commands('migration.generate');
+
+		// Bind the Repository Interface to $app['migrations.repository']
+		$this->app->bind('Illuminate\Database\Migrations\MigrationRepositoryInterface', function($app) {
+			return $app['migration.repository'];
+		});
 	}
 
 	/**
@@ -41,7 +46,6 @@ class MigrationsGeneratorServiceProvider extends ServiceProvider {
 	 */
 	public function boot()
 	{
-		$this->package( 'xethron/migration-from-table' );
 	}
 
 	/**


### PR DESCRIPTION
This PR addresses the changes needed to get this package to load happily in Laravel 5.0.  I'm not making any claim that this work should be 'good enough' for a new stable rev, but as a stop-gap solution until a rewrite/re-integration of this package can be managed.

Notable changes include composer dependencies and how package service providers are loaded.  

I've also done a very basic update to the broken aspects of `way/generators` to get it to function in 5.0.  My work is based off of the `3.3` tagged commit, which was as far as Jeffrey Way pushed until he dropped L5 support.  To the best of my testing this is sufficient for the needs of `migrations-generator`.  I've updated the `composer.json` to point to my fork of `way/generators`.  The only changes necessary for generators to work were config registration and dropping the `$this->package()` call in the Service Provider.

No changes to the `readme.md` are necessary.  There may well be conflicts/bugs with anyone who needs to use `way/generators` for work outside of this package.

