### PR TITLE
Update Laravel 5 Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ For Laravel 5 installations, use version: "dev-l5" as follows:
     "xethron/migrations-generator": "dev-l5"
 }
 ```
+Also, due to a composer bug, you may need explicitly add the forked `way/generators` repo:
+```json
+"repositories": [
+    {
+        "type": "git",
+        "url": "git@github.com:jamisonvalenta/Laravel-4-Generators.git"
+    }
+]
+```
+For those who use `way/generators`: you will not be able to resolve a package version for both this package and `way/generators`. `composer update` without requiring `way/generators` to generate your migrations. Then remove `xethron/migrations-generator`, add your preferred version, and `composer update` again.  
 
 ## Install
 


### PR DESCRIPTION
Composer has this weird bug where all private packages (or, in our case public but not on packagist) need to be declared in the project's root `composer.json`, even if they are properly declared in a given package's `composer.json` (as it is with the `l5` fork).

So, we need to instruct users on how to make this package resolve until composer gets better.  Which will be  someday I'm sure.