### PR TITLE
fix docs for Laravel 5 docs for composer project stability:stable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ You also need to point to the fork of the `way/generators` repo:
     }
 ]
 ```
-Note: `feature/laravel-five-stable` was forked from `way/generators` `3.0.3` and was made Laravel `5.0` ready. 
+Note: `feature/laravel-five-stable` was forked from `way/generators` `3.0.3` and was made Laravel `5.0` ready. Jeffrey Way has discontinued support for Laravel 5, so the other `artisan generate:` commands may not have been made `5.0` compatible.  Investigate the `artisan make:` commands for substitutes, contribute to Laravel to extend generation support, or fix it and submit a PR to `jamisonvalenta/feature/laravel-five-stable`.
 
 ## Install
 
@@ -39,7 +39,7 @@ Edit your composer.json file to require `xethron/migrations-generator` and run `
 }
 ```
 
-Next, add the following service provider:
+Next, add the following service providers:
 
 ```
 'Way\Generators\GeneratorsServiceProvider',

--- a/README.md
+++ b/README.md
@@ -12,13 +12,14 @@ Generate Laravel Migrations from an existing database, including indexes and for
 
 Thanks to @jamisonvalenta, you can now generate Migrations in Laravel 5!
 
-For Laravel 5 installations, use version: "dev-l5" as follows:
+For Laravel 5 installations, add the specified packages to your `composer.json` 
 ```json
 "require-dev": {
-    "xethron/migrations-generator": "dev-l5"
+    "xethron/migrations-generator": "dev-l5",
+    "way/generators": "dev-feature/laravel-five-stable",
 }
 ```
-Also, due to a composer bug, you may need explicitly add the forked `way/generators` repo:
+You also need to point to the fork of the `way/generators` repo:
 ```json
 "repositories": [
     {
@@ -27,7 +28,7 @@ Also, due to a composer bug, you may need explicitly add the forked `way/generat
     }
 ]
 ```
-For those who use `way/generators`: you will not be able to resolve a package version for both this package and `way/generators`. `composer update` without requiring `way/generators` to generate your migrations. Then remove `xethron/migrations-generator`, add your preferred version, and `composer update` again.  
+Note: `feature/laravel-five-stable` was forked from `way/generators` `3.0.3` and was made Laravel `5.0` ready. 
 
 ## Install
 


### PR DESCRIPTION
Thanks to composer clarification and problem solving from @MarcGuay and @alcohol, I've updated the docs to allow for successful composer installation for project root `minimum-stability: stable` settings.

Also added notes on the `way/generators` fork compatibility.