### PR TITLE
Support table names containing slashes

### DIFF
--- a/src/Xethron/MigrationsGenerator/MigrateGenerateCommand.php
+++ b/src/Xethron/MigrationsGenerator/MigrateGenerateCommand.php
@@ -254,7 +254,8 @@ class MigrateGenerateCommand extends GeneratorCommand {
 	protected function getFileGenerationPath()
 	{
 		$path = $this->getPathByOptionOrConfig( 'path', 'migration_target_path' );
-		$fileName = $this->getDatePrefix() . '_' . $this->migrationName . '.php';
+		$migrationName = str_replace('/', '_', $this->migrationName);
+		$fileName = $this->getDatePrefix() . '_' . $migrationName . '.php';
 
 		return "{$path}/{$fileName}";
 	}


### PR DESCRIPTION
Running `artisan migrate:generate` on tables with names containing slashes causes the tool to fail:

```
[ErrorException]
 file_put_contents(/www/api/database/migrations/2016_04_14_162259_name/with/slash_table.php): failed to
   open stream: No such file or directory
```

This PR converts forward slashes into underscores in the generation of the migration file name. This should be applicable to both master and the l5 branch.