### PR TITLE
Doctrine does not support JSON

### DIFF
--- a/src/Xethron/MigrationsGenerator/Generators/SchemaGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/SchemaGenerator.php
@@ -40,6 +40,7 @@ class SchemaGenerator {
 	public function __construct($database, $ignoreIndexNames, $ignoreForeignKeyNames)
 	{
 		$connection = DB::connection($database)->getDoctrineConnection();
+		$connection->getDatabasePlatform()->registerDoctrineTypeMapping('json', 'text');
 		$connection->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
 		$connection->getDatabasePlatform()->registerDoctrineTypeMapping('bit', 'boolean');
 


### PR DESCRIPTION
If your database contains JSON data types doctrine will throw:

[Doctrine\DBAL\DBALException]
Unknown database type json requested, Doctrine\DBAL\Platforms\MySqlPlatform may not support it.

To fix this we can treat JSON as text (using the same mechanism that was used for bit and enum).