### PR TITLE
Put t or f when default is a boolean

### DIFF
--- a/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
@@ -92,6 +92,8 @@ class FieldGenerator {
 			$type = $column->getType()->getName();
 			$length = $column->getLength();
 			$default = $column->getDefault();
+			if (is_bool($default))
+				$default = $default === true ? 't' : 'f';
 			$nullable = (!$column->getNotNull());
 			$index = $indexGenerator->getIndex($name);
 

--- a/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
@@ -93,7 +93,7 @@ class FieldGenerator {
 			$length = $column->getLength();
 			$default = $column->getDefault();
 			if (is_bool($default))
-				$default = $default === true ? 't' : 'f';
+				$default = $default === true ? 1 : 0;
 			$nullable = (!$column->getNotNull());
 			$index = $indexGenerator->getIndex($name);
 


### PR DESCRIPTION
Boolean defaults somehow gets a blank value when generating migrations.  Here's a simple patch to have have 't' or 'f' when it's a boolean value.
