### PR TITLE
DB::raw breaks postgres default booleans

### DIFF
--- a/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
@@ -176,11 +176,10 @@ class FieldGenerator {
 	 */
 	protected function getDefault($default, &$type)
 	{
-		if (in_array($default, ['CURRENT_TIMESTAMP'])) {
+		if (in_array($default, ['CURRENT_TIMESTAMP'], true)) {
 			if ($type == 'dateTime')
 				$type = 'timestamp';
-			if ($type != 'boolean')
-				$default = $this->decorate('DB::raw', $default);
+			$default = $this->decorate('DB::raw', $default);
 		} elseif (in_array($type, ['string', 'text']) or !is_numeric($default)) {
 			$default = $this->argsToString($default);
 		}

--- a/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
@@ -92,6 +92,8 @@ class FieldGenerator {
 			$type = $column->getType()->getName();
 			$length = $column->getLength();
 			$default = $column->getDefault();
+			if (is_bool($default))
+				$default = $default === true ? 't' : 'f';
 			$nullable = (!$column->getNotNull());
 			$index = $indexGenerator->getIndex($name);
 

--- a/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
@@ -179,7 +179,8 @@ class FieldGenerator {
 		if (in_array($default, ['CURRENT_TIMESTAMP'])) {
 			if ($type == 'dateTime')
 				$type = 'timestamp';
-			$default = $this->decorate('DB::raw', $default);
+			if ($type != 'boolean')
+				$default = $this->decorate('DB::raw', $default);
 		} elseif (in_array($type, ['string', 'text']) or !is_numeric($default)) {
 			$default = $this->argsToString($default);
 		}

--- a/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
@@ -93,7 +93,7 @@ class FieldGenerator {
 			$length = $column->getLength();
 			$default = $column->getDefault();
 			if (is_bool($default))
-				$default = $default === true ? 't' : 'f';
+				$default = $default === true ? 1 : 0;
 			$nullable = (!$column->getNotNull());
 			$index = $indexGenerator->getIndex($name);
 


### PR DESCRIPTION
When there's a DB::raw('0') in a boolean's default value, in PostgreSQL, the following error occurs:
```
  [PDOException]                                                                                                                 
  SQLSTATE[42804]: Datatype mismatch: 7 ERROR:  column "separator" is of type boolean but default expression is of type integer  
  HINT:  You will need to rewrite or cast the expression.                                                                        
```
Here's a sample schema that generates the error:
```php
                Schema::create('menus', function(Blueprint $table)
                {
                        $table->integer('id', true);
                        $table->string('name');
                        $table->string('label');
                        $table->integer('position')->default(0);
                        $table->string('icon')->nullable();
                        $table->boolean('separator')->default(DB::raw('0'));
                        $table->string('url')->nullable();
                        $table->boolean('enabled')->default(DB::raw('0'));
                        $table->integer('parent_id')->default(0);
                        $table->integer('route_id')->nullable();
                        $table->integer('permission_id')->nullable();
                        $table->timestamps();
                });
```
Here's the schema that doesn't have the error:
```php
                Schema::create('menus', function(Blueprint $table)
                {
                        $table->integer('id', true);
                        $table->string('name');
                        $table->string('label');
                        $table->integer('position')->default(0);
                        $table->string('icon')->nullable();
                        $table->boolean('separator')->default(0);
                        $table->string('url')->nullable();
                        $table->boolean('enabled')->default(0);
                        $table->integer('parent_id')->default(0);
                        $table->integer('route_id')->nullable();
                        $table->integer('permission_id')->nullable();
                        $table->timestamps();
                });
```