### PR TITLE
Returns all foreign key fields and references

### DIFF
--- a/src/Xethron/MigrationsGenerator/Generators/ForeignKeyGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/ForeignKeyGenerator.php
@@ -28,8 +28,8 @@ class ForeignKeyGenerator {
 		foreach ( $foreignKeys as $foreignKey ) {
 			$fields[] = [
 				'name' => $this->getName($foreignKey, $ignoreForeignKeyNames),
-				'field' => $foreignKey->getLocalColumns()[0],
-				'references' => $foreignKey->getForeignColumns()[0],
+				'field' => $foreignKey->getLocalColumns(),
+				'references' => $foreignKey->getForeignColumns(),
 				'on' => $foreignKey->getForeignTableName(),
 				'onUpdate' => $foreignKey->hasOption('onUpdate') ? $foreignKey->getOption('onUpdate') : 'RESTRICT',
 				'onDelete' => $foreignKey->hasOption('onDelete') ? $foreignKey->getOption('onDelete') : 'RESTRICT',

--- a/src/Xethron/MigrationsGenerator/Syntax/AddForeignKeysToTable.php
+++ b/src/Xethron/MigrationsGenerator/Syntax/AddForeignKeysToTable.php
@@ -14,14 +14,14 @@ class AddForeignKeysToTable extends Table {
 	 */
 	protected function getItem(array $foreignKey)
 	{
-		$value = $foreignKey['field'];
+		$value = $foreignKey['field'][0];
 		if ( ! empty($foreignKey['name'])) {
 			$value .= "', '". $foreignKey['name'];
 		}
 		$output = sprintf(
 			"\$table->foreign('%s')->references('%s')->on('%s')",
 			$value,
-			$foreignKey['references'],
+			$foreignKey['references'][0],
 			$foreignKey['on']
 		);
 		if ($foreignKey['onUpdate']) {


### PR DESCRIPTION
Returns all foreign key fields and references, and only uses the first element when actually generating the migration file. This allow for more flexibility. See https://github.com/Xethron/migrations-generator/issues/125