### PR TITLE
Support for Laravel 5.5.x

### DIFF
--- a/src/Xethron/MigrationsGenerator/MigrateGenerateCommand.php
+++ b/src/Xethron/MigrationsGenerator/MigrateGenerateCommand.php
@@ -133,7 +133,7 @@ class MigrateGenerateCommand extends GeneratorCommand {
 	 *
 	 * @return void
 	 */
-	public function fire()
+	public function handle()
 	{
 		$this->info( 'Using connection: '. $this->option( 'connection' ) ."\n" );
         if ($this->option('connection') !== $this->config->get('database.default')) {


### PR DESCRIPTION
Fix error Method Xethron\MigrationsGenerator\MigrateGenerateCommand::handle() does not exist