### PR TITLE
Do not set the column created_at or updated_at to the type timestamps…

### DIFF
--- a/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
@@ -124,10 +124,12 @@ class FieldGenerator {
 					$nullable = false;
 					$type = 'softDeletes';
 					$name = '';
-				} elseif ($name == 'created_at' and isset($fields['updated_at'])) {
+				} elseif ($name == 'created_at' and isset($fields['updated_at']) and empty($index)
+                    and !in_array("index", $fields['updated_at']['decorators'])) {
 					$fields['updated_at'] = ['field' => '', 'type' => 'timestamps'];
 					continue;
-				} elseif ($name == 'updated_at' and isset($fields['created_at'])) {
+				} elseif ($name == 'updated_at' and isset($fields['created_at']) and empty($index)
+                    and !in_array("index", $fields['created_at']['decorators'])) {
 					$fields['created_at'] = ['field' => '', 'type' => 'timestamps'];
 					continue;
 				}


### PR DESCRIPTION
… if there exist an index

Use case:
If you want generate a migration from a table where exist an index on created_at, the index will be ignored. Now if there is an index on created_at or updadet_at, the type is set to a dateTime with index.