### PR TITLE
Use correct connection on getTablePrefix()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": ">=4.0.0",
-		"mockery/mockery": ">=0.9.0",
+		"mockery/mockery": ">=1.0.0",
 		"illuminate/cache": ">=4.1.0",
 		"illuminate/console": ">=4.1.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
 	},
 	"require-dev": {
 		"phpunit/phpunit": ">=4.0.0",
-		"mockery/mockery": ">=1.0.0",
+		"mockery/mockery": "0.9.0",
 		"illuminate/cache": ">=4.1.0",
 		"illuminate/console": ">=4.1.0"
 	},

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
    convertWarningsToExceptions="true"
    processIsolation="false"
    stopOnFailure="false"
-   syntaxCheck="false"
    stderr="true"
 >
   <testsuites>
@@ -22,6 +21,6 @@
     </whitelist>
   </filter>
   <logging>
-    <log type="coverage-html" target="report/" charset="UTF-8" yui="true" />
+    <log type="coverage-html" target="report/" />
   </logging>
 </phpunit>

--- a/src/Xethron/MigrationsGenerator/MigrationsGeneratorServiceProvider.php
+++ b/src/Xethron/MigrationsGenerator/MigrationsGeneratorServiceProvider.php
@@ -29,13 +29,15 @@ class MigrationsGeneratorServiceProvider extends ServiceProvider {
                 );
             });
 
-		$this->commands('migration.generate');
 
-		// Bind the Repository Interface to $app['migrations.repository']
-		$this->app->bind('Illuminate\Database\Migrations\MigrationRepositoryInterface', function($app) {
-			return $app['migration.repository'];
-		});
-	}
+        $this->commands('migration.generate');
+
+        // Bind the Repository Interface to $app['migrations.repository']
+        $this->app->bind('Illuminate\Database\Migrations\MigrationRepositoryInterface', function($app) {
+            return $app['migration.repository'];
+        });
+
+    }
 
 	/**
 	 * Bootstrap the application events.

--- a/src/Xethron/MigrationsGenerator/Syntax/Table.php
+++ b/src/Xethron/MigrationsGenerator/Syntax/Table.php
@@ -21,7 +21,7 @@ abstract class Table extends \Way\Generators\Syntax\Table{
      */
 	public function run(array $fields, $table, $connection = null, $method = 'table')
 	{
-		$table = substr($table, strlen(\DB::getTablePrefix()));
+		$table = substr($table, strlen(\DB::connection($connection)->getTablePrefix()));
 		$this->table = $table;
         if (!is_null($connection)) $method = 'connection(\''.$connection.'\')->'.$method;
 		$compiled = $this->compiler->compile($this->getTemplate(), ['table'=>$table,'method'=>$method]);

--- a/src/Xethron/MigrationsGenerator/Syntax/Table.php
+++ b/src/Xethron/MigrationsGenerator/Syntax/Table.php
@@ -21,7 +21,8 @@ abstract class Table extends \Way\Generators\Syntax\Table{
      */
 	public function run(array $fields, $table, $connection = null, $method = 'table')
 	{
-		$table = substr($table, strlen(\DB::connection($connection)->getTablePrefix()));
+	    $prefix = is_null($connection) ? \DB::getTablePrefix() : \DB::connection($connection)->getTablePrefix();
+		$table = substr($table, strlen($prefix));
 		$this->table = $table;
         if (!is_null($connection)) $method = 'connection(\''.$connection.'\')->'.$method;
 		$compiled = $this->compiler->compile($this->getTemplate(), ['table'=>$table,'method'=>$method]);

--- a/tests/Xethron/MigrationsGenerator/MigrationsGeneratorServiceProviderTest.php
+++ b/tests/Xethron/MigrationsGenerator/MigrationsGeneratorServiceProviderTest.php
@@ -1,9 +1,10 @@
 <?php namespace Xethron\MigrationsGenerator;
 
+use Illuminate\Contracts\Config\Repository;
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class MigrationsGeneratorServiceProviderTest extends PHPUnit_Framework_TestCase {
+class MigrationsGeneratorServiceProviderTest extends TestCase {
   
   public function tearDown()
   {
@@ -24,19 +25,11 @@ class MigrationsGeneratorServiceProviderTest extends PHPUnit_Framework_TestCase 
         'Illuminate\Database\Migrations\MigrationRepositoryInterface',
         Mockery::any()
       );
-      
+
     $app_mock
-      ->shouldReceive('bind')
+      ->shouldReceive('singleton')
       ->atLeast()->once()
-      ->with(
-        'migration.generate',
-        Mockery::any()
-      );
-      
-    $app_mock
-      ->shouldReceive('share')
-      ->atLeast()->once()
-      ->with(
+      ->with('migration.generate',
         Mockery::on(function($callback) {
           $mock = $this->get_app_mock();
 
@@ -99,7 +92,10 @@ class MigrationsGeneratorServiceProviderTest extends PHPUnit_Framework_TestCase 
 
     $service_provider_mock
       ->shouldReceive('commands')
-      ->atLeast()->once();
+      ->atLeast()->once()
+        ->with(
+            'migration.generate'
+        );
 
     $service_provider_mock->register();
   }
@@ -165,7 +161,7 @@ class MigrationsGeneratorServiceProviderTest extends PHPUnit_Framework_TestCase 
 
   protected function get_repository_mock()
   {
-    return Mockery::mock('Illuminate\Config\Repository')
+    return Mockery::mock(Repository::class)
       ->shouldAllowMockingProtectedMethods()
       ->makePartial();
   }

--- a/tests/Xethron/MigrationsGenerator/MigrationsGeneratorServiceProviderTest.php
+++ b/tests/Xethron/MigrationsGenerator/MigrationsGeneratorServiceProviderTest.php
@@ -161,7 +161,7 @@ class MigrationsGeneratorServiceProviderTest extends TestCase {
 
   protected function get_repository_mock()
   {
-    return Mockery::mock(Repository::class)
+    return Mockery::mock('\Illuminate\Contracts\Config\Repository')
       ->shouldAllowMockingProtectedMethods()
       ->makePartial();
   }

--- a/tests/Xethron/MigrationsGenerator/MigrationsGeneratorTest.php
+++ b/tests/Xethron/MigrationsGenerator/MigrationsGeneratorTest.php
@@ -1,9 +1,9 @@
 <?php namespace Xethron\MigrationsGenerator;
 
 use Mockery;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class MigrationsGeneratorTest extends PHPUnit_Framework_TestCase {
+class MigrationsGeneratorTest extends TestCase {
 
   public function tearDown()
   {
@@ -15,6 +15,6 @@ class MigrationsGeneratorTest extends PHPUnit_Framework_TestCase {
   */
   public function registers_migrations_generator()
   {
-    
+    $this->markTestSkipped('No tests implemented yet.');
   }
 }


### PR DESCRIPTION
This fixes getTablePrefix to refer to the connection when one is specified (eg: on multi-database installs). Also rolls up the pull request #160 which I needed to allow the existing tests to pass under php 7.2.