### PR TITLE
fixed issue in enum fields generation

### DIFF
--- a/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
@@ -73,8 +73,8 @@ class FieldGenerator {
 	protected function setEnum(array $fields, $table)
 	{
 		foreach ($this->getEnum($table) as $column) {
-			$fields[$column->column_name]['type'] = 'enum';
-			$fields[$column->column_name]['args'] = str_replace('enum(', 'array(', $column->column_type);
+			$fields[$column->COLUMN_NAME]['type'] = 'enum';
+			$fields[$column->COLUMN_NAME]['args'] = str_replace('enum(', 'array(', $column->COLUMN_TYPE);
 		}
 		return $fields;
 	}

--- a/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
@@ -86,7 +86,7 @@ class FieldGenerator {
 	 */
 	protected function getFields($columns, IndexGenerator $indexGenerator)
 	{
-		$fields = array();
+		$fields = [];
 		foreach ($columns as $column) {
 			$name = $column->getName();
 			$type = $column->getType()->getName();
@@ -242,7 +242,7 @@ class FieldGenerator {
 	 */
 	protected function getMultiFieldIndexes(IndexGenerator $indexGenerator)
 	{
-		$indexes = array();
+		$indexes = [];
 		foreach ($indexGenerator->getMultiFieldIndexes() as $index) {
 			$indexArray = [
 				'field' => $index->columns,

--- a/src/Xethron/MigrationsGenerator/Generators/ForeignKeyGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/ForeignKeyGenerator.php
@@ -23,7 +23,7 @@ class ForeignKeyGenerator {
 
 		$foreignKeys = $schema->listTableForeignKeys($table);
 
-		if ( empty( $foreignKeys ) ) return array();
+		if ( empty( $foreignKeys ) ) return [];
 
 		foreach ( $foreignKeys as $foreignKey ) {
 			$fields[] = [

--- a/src/Xethron/MigrationsGenerator/Generators/IndexGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/IndexGenerator.php
@@ -25,8 +25,8 @@ class IndexGenerator {
 	 */
 	public function __construct($table, $schema, $ignoreIndexNames)
 	{
-		$this->indexes = array();
-		$this->multiFieldIndexes = array();
+		$this->indexes = [];
+		$this->multiFieldIndexes = [];
 		$this->ignoreIndexNames = $ignoreIndexNames;
 
 		$indexes = $schema->listTableIndexes( $table );

--- a/src/Xethron/MigrationsGenerator/MigrateGenerateCommand.php
+++ b/src/Xethron/MigrationsGenerator/MigrateGenerateCommand.php
@@ -61,13 +61,13 @@ class MigrateGenerateCommand extends GeneratorCommand {
 	 * Namely: Columns, Indexes and Foreign Keys
 	 * @var array
 	 */
-	protected $fields = array();
+	protected $fields = [];
 
 	/**
 	 * List of Migrations that has been done
 	 * @var array
 	 */
-	protected $migrations = array();
+	protected $migrations = [];
 
 	/**
 	 * @var bool

--- a/src/Xethron/MigrationsGenerator/MigrationsGeneratorServiceProvider.php
+++ b/src/Xethron/MigrationsGenerator/MigrationsGeneratorServiceProvider.php
@@ -53,7 +53,7 @@ class MigrationsGeneratorServiceProvider extends ServiceProvider {
 	 */
 	public function provides()
 	{
-		return array();
+		return [];
 	}
 
 }

--- a/src/Xethron/MigrationsGenerator/Syntax/Table.php
+++ b/src/Xethron/MigrationsGenerator/Syntax/Table.php
@@ -36,7 +36,7 @@ abstract class Table extends \Way\Generators\Syntax\Table{
 	 */
 	protected function getItems(array $items)
 	{
-		$result = array();
+		$result = [];
 		foreach($items as $item) {
 			$result[] = $this->getItem($item);
 		}


### PR DESCRIPTION
Generating migration of table with enum field occurs error because object $column contains variables in upper registry