### PR TITLE
Fixed exception in generating enum column type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 report
 composer.lock
+.idea

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,3 +1,0 @@
-
-# Default ignored files
-/workspace.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+
+# Default ignored files
+/workspace.xml

--- a/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
@@ -73,8 +73,8 @@ class FieldGenerator {
 	protected function setEnum(array $fields, $table)
 	{
 		foreach ($this->getEnum($table) as $column) {
-            $column->column_name = $column->column_name ?? $column->COLUMN_NAME;
-            $column->column_type = $column->column_type ?? $column->COLUMN_TYPE;
+            $column->column_name = property_exists($column, 'column_name') ? $column->column_name : $column->COLUMN_NAME;
+            $column->column_type = property_exists($column, 'column_type') ? $column->column_type : $column->COLUMN_TYPE;
 			$fields[$column->column_name]['type'] = 'enum';
 			$fields[$column->column_name]['args'] = str_replace('enum(', 'array(', $column->column_type);
 		}

--- a/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/FieldGenerator.php
@@ -73,6 +73,8 @@ class FieldGenerator {
 	protected function setEnum(array $fields, $table)
 	{
 		foreach ($this->getEnum($table) as $column) {
+            $column->column_name = $column->column_name ?? $column->COLUMN_NAME;
+            $column->column_type = $column->column_type ?? $column->COLUMN_TYPE;
 			$fields[$column->column_name]['type'] = 'enum';
 			$fields[$column->column_name]['args'] = str_replace('enum(', 'array(', $column->column_type);
 		}

--- a/src/Xethron/MigrationsGenerator/MigrateGenerateCommand.php
+++ b/src/Xethron/MigrationsGenerator/MigrateGenerateCommand.php
@@ -427,7 +427,7 @@ class MigrateGenerateCommand extends GeneratorCommand {
 			['connection', 'c', InputOption::VALUE_OPTIONAL, 'The database connection to use.', $this->config->get( 'database.default' )],
 			['tables', 't', InputOption::VALUE_OPTIONAL, 'A list of Tables you wish to Generate Migrations for separated by a comma: users,posts,comments'],
 			['ignore', 'i', InputOption::VALUE_OPTIONAL, 'A list of Tables you wish to ignore, separated by a comma: users,posts,comments' ],
-            ['ignore-created-migration', 'icm', InputOption::VALUE_OPTIONAL, 'Flag to ignore migrations already created' ],
+            ['ignore-created-migration', 'icm', null, 'Flag to ignore migrations already created' ],
             ['path', 'p', InputOption::VALUE_OPTIONAL, 'Where should the file be created?'],
 			['templatePath', 'tp', InputOption::VALUE_OPTIONAL, 'The location of the template for this generator'],
 			['defaultIndexNames', null, InputOption::VALUE_NONE, 'Don\'t use db index names for migrations'],


### PR DESCRIPTION
While using the package for a project, I get this error:

In FieldGenerator.php line 79:                                             
 Undefined property: stdClass::$column_name  
When I dumped the content of $column, I saw it's this:

stdClass Object
(
    [COLUMN_NAME] => status
    [COLUMN_TYPE] => enum('UNSET','SELECTED','PASSED','FAILED','PROFILE_CREATED','PROFILE_EDITED')
)
So, I modified that part of the code to be able to set the $column->column_name as $column->COLUMN_NAME and $column->column_type too.