### PR TITLE
remove quotation from tablename if exit

### DIFF
--- a/src/Xethron/MigrationsGenerator/Generators/SchemaGenerator.php
+++ b/src/Xethron/MigrationsGenerator/Generators/SchemaGenerator.php
@@ -67,7 +67,9 @@ class SchemaGenerator {
 	 */
 	public function getTables()
 	{
-		return $this->schema->listTableNames();
+		$tableNames = $this->schema->listTableNames();
+		$tableNames = array_map(function($tableName){return trim($tableName,'"');}, $tableNames);
+		return $tableNames;
 	}
 
 	public function getFields($table)


### PR DESCRIPTION
I've removed quotation mark if exist in tablename value.
facing as issue during generation of file and also tablename

Database : **PostgreSQL**

I am using PostgreSQL, Ive created table in capital letters "SERP_feature" 
![image](https://user-images.githubusercontent.com/40670677/94963427-c1defa80-0515-11eb-9c0e-84a0c9f8fc05.png)



When I have tried to generate migration file 
throw an error because filename must not include quotation mark 

> filename must be **create_SERP_feature_table.php**, where it takes **create_"SERP_feature"_table.php**

![image](https://user-images.githubusercontent.com/40670677/94964152-f1423700-0516-11eb-8b7e-cf7642b51edb.png)

So, Pls accept my pull request and issue will resolve

Thank you,